### PR TITLE
Update yamllint.json: new-lines correction

### DIFF
--- a/src/schemas/json/yamllint.json
+++ b/src/schemas/json/yamllint.json
@@ -593,7 +593,7 @@
                   "title": "Type",
                   "description": "Unix to use UNIX-typed new line characters (\n), or dos to use DOS-typed new line characters (\r\n).",
                   "type": "string",
-                  "enum": ["unix", "dos"],
+                  "enum": ["unix", "dos", "platform"],
                   "default": "unix"
                 }
               }


### PR DESCRIPTION
According to 
https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.new_lines a possible value for new-lines' type is missing
